### PR TITLE
Fix UAA login error by adding uaa.none scope to admin user

### DIFF
--- a/templates/uaa-config-updated.yaml
+++ b/templates/uaa-config-updated.yaml
@@ -152,4 +152,4 @@ data:
           - clients.read
     scim:
       users:
-      - admin|admin_secret|admin@admin.admin|Admin|Admin|cloud_controller.admin,scim.read,scim.write,doppler.firehose,openid,routing.router_groups.read,routing.router_groups.write,network.admin,clients.read
+      - admin|admin_secret|admin@admin.admin|Admin|Admin|cloud_controller.admin,scim.read,scim.write,doppler.firehose,openid,routing.router_groups.read,routing.router_groups.write,network.admin,clients.read,uaa.none


### PR DESCRIPTION
## Summary

This PR fixes the `cf login` authentication error that was occurring with the UAA configuration:

```
{"error":"invalid_scope","error_description":"[uaa.none] is invalid. This user is not allowed any of the requested scopes"}
```

## Root Cause

The `cf` client in the UAA configuration (line 130 of `templates/uaa-config-updated.yaml`) has `authorities: uaa.none`, but the admin user (line 155) didn't have `uaa.none` in their allowed scopes list. This mismatch caused authentication to fail when users tried to log in.

## Changes

- Added `uaa.none` to the admin user's scope list in `templates/uaa-config-updated.yaml`

## Testing

To verify the fix:

```bash
devbox run make deploy-korifi
devbox run cf api localhost --skip-ssl-validation
devbox run CF_TRACE=true cf login -u admin -p admin_secret
```

The login should now succeed without the `invalid_scope` error.

Fixes rkoster/rubionic-workspace#48