### PR TITLE
Fix UAA invalid_scope error by removing uaa.none authority

### DIFF
--- a/templates/uaa-config-updated.yaml
+++ b/templates/uaa-config-updated.yaml
@@ -127,12 +127,11 @@ data:
           authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write
         cf:
           access-token-validity: 1200
-          authorities: uaa.none
           authorized-grant-types: password,refresh_token,urn:ietf:params:oauth:grant-type:jwt-bearer
           override: true
           refresh-token-validity: 2592000
           secret: ''
-          scopes:
+          scope:
           - network.admin
           - network.write
           - cloud_controller.read


### PR DESCRIPTION
## Summary

Fixes the UAA authentication error that was preventing `cf login` from working:
```
Raw Response: {"error":"invalid_scope","error_description":"[uaa.none] is invalid. This user is not allowed any of the requested scopes"}
```

## Changes

- Removed the `authorities: uaa.none` field from the `cf` OAuth client configuration in `templates/uaa-config-updated.yaml`
- Changed `scopes:` to `scope:` to match UAA's expected configuration format

## Root Cause

The UAA configuration incorrectly specified `authorities: uaa.none` for the `cf` client. The `cf` client is a public OAuth2 client that uses the password grant type to authenticate users. It should not have the `uaa.none` authority because:

1. `uaa.none` is not a valid scope that can be granted to users
2. The client requests scopes based on what the authenticated user possesses
3. Password grant type clients should not have authorities defined - they inherit the user's scopes

## Testing

To verify the fix works:

```bash
devbox run make deploy-korifi
devbox run cf api localhost --skip-ssl-validation
devbox run cf login -u admin -p admin_secret
```

The login should now succeed without the invalid_scope error.

Fixes rkoster/rubionic-workspace#47