### PR TITLE
Fix UAA cf client scope configuration format

### DIFF
--- a/templates/uaa-config-updated.yaml
+++ b/templates/uaa-config-updated.yaml
@@ -127,28 +127,12 @@ data:
           authorities: clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write
         cf:
           access-token-validity: 1200
+          authorities: uaa.none
           authorized-grant-types: password,refresh_token,urn:ietf:params:oauth:grant-type:jwt-bearer
           override: true
           refresh-token-validity: 2592000
+          scope: network.admin,network.write,cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read,routing.router_groups.write,cloud_controller.admin_read_only,cloud_controller.global_auditor,perm.admin,clients.read
           secret: ''
-          scope:
-          - network.admin
-          - network.write
-          - cloud_controller.read
-          - cloud_controller.write
-          - openid
-          - password.write
-          - cloud_controller.admin
-          - scim.read
-          - scim.write
-          - doppler.firehose
-          - uaa.user
-          - routing.router_groups.read
-          - routing.router_groups.write
-          - cloud_controller.admin_read_only
-          - cloud_controller.global_auditor
-          - perm.admin
-          - clients.read
     scim:
       users:
       - admin|admin_secret|admin@admin.admin|Admin|Admin|cloud_controller.admin,scim.read,scim.write,doppler.firehose,openid,routing.router_groups.read,routing.router_groups.write,network.admin,clients.read


### PR DESCRIPTION
## Summary

Fixes the UAA authentication error by correcting the `scope` field format in the `cf` client configuration.

## Root Cause Analysis

The error `"[uaa.none] is invalid. This user is not allowed any of the requested scopes"` was caused by incorrect scope configuration format.

### Investigation Process

1. **Analyzed UAA source code** (`ClientAdminBootstrap.java`):
   - The Bootstrap expects `scope` to be a comma-separated string
   - When scope is empty, it defaults to `["uaa.none"]`
   - `uaa.none` is not a valid user scope, causing authentication to fail

2. **Compared with canonical cf-deployment**:
   - Uses `scopes:` (plural) with array format
   - Includes `authorities: uaa.none`

3. **Discovered ERB template processing** (in `uaa-release`):
   ```ruby
   if !client['scopes'].nil?
     client_data.delete('scopes')
     if client['scopes'].is_a? Array
       client_data['scope'] = client['scopes'].join(',')
     end
   end
   ```
   - cf-deployment uses ERB templates that convert `scopes` array to `scope` string
   - Our Kubernetes ConfigMap bypasses this processing

## Changes

- ✅ Changed `scope:` from YAML array to comma-separated string
- ✅ Added `authorities: uaa.none` to match cf-deployment
- ✅ Reordered fields to match canonical configuration

## Testing

To verify the fix:

```bash
devbox run make deploy-korifi
devbox run cf api localhost --skip-ssl-validation
devbox run cf login -u admin -p admin_secret
```

The login should now succeed without the `invalid_scope` error.

## References

- UAA Source: `server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrap.java`
- ERB Template: `cloudfoundry/uaa-release/jobs/uaa/templates/config/uaa.yml.erb`
- Canonical Config: `cloudfoundry/cf-deployment/cf-deployment.yml`

Fixes rkoster/rubionic-workspace#47

---

**Note**: This supersedes PR #5 which had an incorrect fix (removing `authorities: uaa.none` instead of fixing the scope format).