### PR TITLE
Move local Docker registry outside k8s cluster

### DIFF
--- a/templates/korifi_config.yaml
+++ b/templates/korifi_config.yaml
@@ -19,7 +19,7 @@ defaultLifecycleConfig:
   type: buildpack
   stack: cflinuxfs3
   stagingMemoryMB: 0
-containerRepositoryPrefix: "localregistry-docker-registry.default.svc.cluster.local:30050/"
+containerRepositoryPrefix: "172.19.0.1:5000/"
 packageRegistrySecretNames:
 - "image-registry-credentials"
 defaultDomainName: apps-127-0-0-1.nip.io

--- a/templates/localregistry-docker-registry.yaml
+++ b/templates/localregistry-docker-registry.yaml
@@ -1,53 +1,8 @@
 apiVersion: v1
-kind: Service
-metadata:
-  name: localregistry-docker-registry
-  namespace: default
-spec:
-  type: NodePort
-  ports:
-  - port: 5000
-    targetPort: 5000
-    nodePort: 30050
-    name: registry
-  selector:
-    app: localregistry-docker-registry
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: localregistry-docker-registry
-  namespace: default
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: localregistry-docker-registry
-  template:
-    metadata:
-      labels:
-        app: localregistry-docker-registry
-    spec:
-      containers:
-      - name: registry
-        image: registry:2
-        ports:
-        - containerPort: 5000
-        env:
-        - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
-          value: /var/lib/registry
-        volumeMounts:
-        - name: registry-storage
-          mountPath: /var/lib/registry
-      volumes:
-      - name: registry-storage
-        emptyDir: {}
----
-apiVersion: v1
 kind: Secret
 metadata:
   name: image-registry-credentials
   namespace: default
 type: kubernetes.io/dockerconfigjson
 data:
-  .dockerconfigjson: eyJhdXRocyI6eyJsb2NhbHJlZ2lzdHJ5LWRvY2tlci1yZWdpc3RyeS5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsOjMwMDUwIjp7InVzZXJuYW1lIjoiIiwicGFzc3dvcmQiOiIiLCJhdXRoIjoiIn19fQ==
+  .dockerconfigjson: eyJhdXRocyI6eyIxNzIuMTkuMC4xOjUwMDAiOnsidXNlcm5hbWUiOiIiLCJwYXNzd29yZCI6IiIsImF1dGgiOiIifX19


### PR DESCRIPTION
## Summary

This PR moves the local Docker registry from inside the Kubernetes cluster to an external Docker container, following the same deployment pattern as UAA.

## Changes

- **External Registry Deployment**: Added `start_local_registry_docker()` function to start the registry as a Docker container (similar to UAA)
- **Network Integration**: Added `connect_registry_to_kind_network()` to connect the registry to the kind network for access via the gateway IP
- **Endpoint Update**: Changed registry endpoint from `localregistry-docker-registry.default.svc.cluster.local:30050` to `172.19.0.1:5000`
- **Containerd Configuration**: Updated kind cluster containerd config to use the kind gateway IP for registry access
- **Credentials Update**: Updated the registry credentials secret for the new endpoint
- **Kubernetes Cleanup**: Removed the k8s Service and Deployment for the registry (keeping only the Secret for credentials)
- **Documentation**: Updated README to reflect the external registry architecture

## Architecture

The registry now runs as a Docker container accessible via the kind network gateway IP (`172.19.0.1`) on port 5000, providing:
- Consistent access from both the host machine and kind cluster pods
- Simplified deployment following the UAA pattern
- Better isolation from the k8s cluster

## Testing

The registry follows the same proven pattern as the UAA deployment:
- Starts before the kind cluster is created
- Connects to the kind network for gateway IP access
- Uses standard Docker registry image with default configuration
- Accessible at `http://172.19.0.1:5000` from within the cluster

Fixes rkoster/rubionic-workspace#55