### PR TITLE
Better success handling for prompter app

### DIFF
--- a/pkg/cfclient/client.go
+++ b/pkg/cfclient/client.go
@@ -383,6 +383,22 @@ func (c *Client) extractLayerToDir(layer v1.Layer, destDir string) error {
 
 	return nil
 }
+func (c *Client) GetApp(appGUID string) (*resource.App, error) {
+	app, err := c.cf.Applications.Get(context.Background(), appGUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get app: %w", err)
+	}
+	return app, nil
+}
+
+func (c *Client) StopApp(appGUID string) error {
+	_, err := c.cf.Applications.Stop(context.Background(), appGUID)
+	if err != nil {
+		return fmt.Errorf("failed to stop app: %w", err)
+	}
+	return nil
+}
+
 func (c *Client) zipDirectory(source, target string) error {
 	zipfile, err := os.Create(target)
 	if err != nil {


### PR DESCRIPTION
Fixes rkoster/rubionic-workspace#60

## Summary

This PR implements better success handling for the prompter app by:

- **Parsing CF_INSTANCE_GUID**: The prompter app now verifies it has access to the Cloud Foundry instance GUID environment variable
- **Stopping app after success**: After successfully uploading the package, the prompter app stops itself using the CF API
- **Goroutine for state monitoring**: The plugin now runs a background goroutine that polls the CF API every 5 seconds to check the app state
- **Detecting success via app state**: Success is detected when the app transitions to STOPPED state, rather than relying solely on log output

## Changes

### pkg/cfclient/client.go
- Added `GetApp(appGUID)` method to retrieve app state from CF API
- Added `StopApp(appGUID)` method to stop a running app via CF API

### cmd/prompter/main.go
- Added parsing of `CF_INSTANCE_GUID` environment variable for validation
- Added parsing of `VCAP_APPLICATION` to get the prompter app's GUID
- Implemented logic to stop the prompter app after successful package upload
- Added `encoding/json` import for VCAP_APPLICATION parsing

### pkg/prompter/deployer.go
- Added `cfClient` field to AppDeployer struct to enable app state monitoring
- Updated `Deploy()` to create and store CF client instance
- Enhanced `MonitorLogs()` with goroutine that polls app state every 5 seconds
- Implemented detection of STOPPED state to gracefully terminate log streaming
- Log streaming now exits cleanly when app stops successfully

## Testing

The implementation follows Cloud Foundry best practices:
- Uses standard CF environment variables (CF_INSTANCE_GUID, VCAP_APPLICATION)
- Leverages existing CF client library methods
- Gracefully handles errors in state monitoring without blocking main flow

## Benefits

1. **More reliable success detection**: No longer dependent on parsing log output
2. **Cleaner termination**: Log streaming ends when app stops, not after timeout
3. **Better user experience**: Plugin knows immediately when prompter completes
4. **Resource efficiency**: Prompter app stops itself instead of running until timeout