### PR TITLE
Mark active prompt with asterisk in cf prompts command

### DIFF
--- a/cmd/prompts.go
+++ b/cmd/prompts.go
@@ -127,7 +127,12 @@ func PromptsCommand(cliConnection plugin.CliConnection, args []string) {
 		os.Exit(1)
 	}
 
-	// Get current org and user info to match cf apps format
+	currentPackageGUID, err := client.GetCurrentDropletPackageGUID(appGUID)
+	if err != nil {
+		fmt.Printf("Error getting current droplet package: %v\n", err)
+		os.Exit(1)
+	}
+
 	currentOrg, err := cliConnection.GetCurrentOrg()
 	if err != nil {
 		fmt.Printf("Error getting current org: %v\n", err)
@@ -140,7 +145,6 @@ func PromptsCommand(cliConnection plugin.CliConnection, args []string) {
 		os.Exit(1)
 	}
 
-	// Print header like cf apps
 	fmt.Printf("Getting packages for app %s in org %s / space %s as %s...\n\n", appName, currentOrg.Name, currentSpace.Name, username)
 
 	if len(packages) == 0 {
@@ -152,6 +156,11 @@ func PromptsCommand(cliConnection plugin.CliConnection, args []string) {
 
 	for _, pkg := range packages {
 		hash := shortHash(pkg.GUID)
+
+		if currentPackageGUID != "" && pkg.GUID == currentPackageGUID {
+			hash = hash + "*"
+		}
+
 		createdAt := pkg.CreatedAt.Format("2006-01-02 15:04:05")
 
 		prompt, hasPrompt := client.GetOriginalPrompt(pkg)


### PR DESCRIPTION
## Summary

- Implements marking of the currently active package (the one the running app instance's droplet is based on) with an asterisk (`*`) after the hash in the `cf prompts` command output
- Adds new method `GetCurrentDropletPackageGUID` to retrieve the package GUID from the app's current droplet by following the app → current_droplet → package relationship chain

## Technical Details

The implementation works by:
1. Getting the app's current droplet GUID from `app.Relationships.CurrentDroplet`
2. Fetching the droplet details using the CF API
3. Extracting the package GUID from the droplet's `package` link
4. Comparing each package GUID in the prompts table with the current one and appending `*` to the hash

## Example Output

```
hash       state   created             type   original prompt
abc1234*   ready   2025-10-05 12:00:00 bits   Update user authentication
def5678    ready   2025-10-04 10:30:00 bits   Add caching layer
```

The asterisk indicates which package revision is currently being used by the running app instance.

Fixes rkoster/rubionic-workspace#63