### PR TITLE
feat: extract prompt-init command for one-time prompter setup

### DIFF
--- a/cmd/prompt_init.go
+++ b/cmd/prompt_init.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"code.cloudfoundry.org/cli/plugin"
+	"github.com/ruben/cf-prompt-cli-plugin/pkg/prompter"
+)
+
+func PromptInitCommand(cliConnection plugin.CliConnection, args []string) {
+	if len(args) == 0 {
+		fmt.Println("Error: Missing required argument APP_NAME")
+		fmt.Println("Usage: cf prompt-init <APP_NAME>")
+		os.Exit(1)
+	}
+
+	appName := args[0]
+	fmt.Printf("Initializing prompter for app: %s\n", appName)
+
+	apiEndpoint, err := cliConnection.ApiEndpoint()
+	if err != nil {
+		fmt.Printf("Error getting API endpoint: %v\n", err)
+		os.Exit(1)
+	}
+
+	token, err := cliConnection.AccessToken()
+	if err != nil {
+		fmt.Printf("Error getting access token: %v\n", err)
+		os.Exit(1)
+	}
+
+	deployer := prompter.NewPrompterInitDeployer(cliConnection, appName)
+
+	if err := deployer.DeployPrompterApp(apiEndpoint, token); err != nil {
+		fmt.Printf("Error deploying prompter app: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Prompter app '%s-prompter' deployed successfully\n", appName)
+}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,8 @@ func (p *PromptPlugin) Run(cliConnection plugin.CliConnection, args []string) {
 		cmd.PromptsCommand(cliConnection, args[1:])
 	case "prompt-push":
 		cmd.PromptPushCommand(cliConnection, args[1:])
+	case "prompt-init":
+		cmd.PromptInitCommand(cliConnection, args[1:])
 	default:
 		fmt.Printf("Error: Unknown command '%s'\n", args[0])
 		os.Exit(1)
@@ -67,6 +69,13 @@ func (p *PromptPlugin) GetMetadata() plugin.PluginMetadata {
 				HelpText: "Update an app to use a specific package's droplet",
 				UsageDetails: plugin.Usage{
 					Usage: "cf prompt-push <APP_NAME> <PACKAGE_HASH>",
+				},
+			},
+			{
+				Name:     "prompt-init",
+				HelpText: "Initialize prompter app for an application (one-time setup)",
+				UsageDetails: plugin.Usage{
+					Usage: "cf prompt-init <APP_NAME>",
 				},
 			},
 		},

--- a/pkg/prompter/deployer.go
+++ b/pkg/prompter/deployer.go
@@ -20,91 +20,56 @@ type AppDeployer struct {
 	cfClient      *cfclient.Client
 }
 
-func NewAppDeployer(cliConnection plugin.CliConnection) *AppDeployer {
+func NewAppDeployer(cliConnection plugin.CliConnection, appName string) *AppDeployer {
 	return &AppDeployer{
 		cliConnection: cliConnection,
-		appName:       fmt.Sprintf("cf-prompter-%d", time.Now().Unix()),
+		appName:       appName,
 	}
 }
 
-func (d *AppDeployer) Deploy(apiEndpoint, token, appID, spaceID, orgID, registryUsername, registryPassword, prompt string) error {
+func (d *AppDeployer) StartPrompter(apiEndpoint, token, appID, spaceID, orgID, registryUsername, registryPassword, prompt string) error {
 	if strings.HasPrefix(strings.ToLower(token), "bearer ") {
 		token = token[7:]
 	}
 
-	// Use original endpoint for plugin's CF client
 	client, err := cfclient.New(apiEndpoint, token)
 	if err != nil {
 		return fmt.Errorf("failed to create CF client: %w", err)
 	}
 	d.cfClient = client
 
-	tempDir, err := os.MkdirTemp("", "cf-prompter-app-*")
-	if err != nil {
-		return fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	prompterBinaryPath := filepath.Join(tempDir, "prompter")
-
-	if len(PrompterBinary) == 0 {
-		return fmt.Errorf("prompter binary not embedded - ensure 'make build-prompter' was run before building the plugin")
-	}
-
-	if err := os.WriteFile(prompterBinaryPath, PrompterBinary, 0755); err != nil {
-		return fmt.Errorf("failed to write prompter binary: %w", err)
-	}
-
-	procfilePath := filepath.Join(tempDir, "Procfile")
-	procfile := "web: ./prompter\n"
-	if err := os.WriteFile(procfilePath, []byte(procfile), 0644); err != nil {
-		return fmt.Errorf("failed to write Procfile: %w", err)
-	}
-
-	manifestPath := filepath.Join(tempDir, "manifest.yml")
 	promptBase64 := base64.StdEncoding.EncodeToString([]byte(prompt))
 
-	// Use internal cluster endpoint for prompter app running inside the cluster
 	prompterApiEndpoint := apiEndpoint
 	if strings.Contains(apiEndpoint, "localhost") {
 		prompterApiEndpoint = "https://korifi-api-svc.korifi.svc.cluster.local"
 	}
 
-	manifest := fmt.Sprintf(`---
-applications:
-- name: %s
-  memory: 1G
-  disk_quota: 2G
-  instances: 1
-  no-route: true
-  health-check-type: process
-  buildpack: paketo-buildpacks/procfile
-  env:
-    CF_ACCESS_TOKEN: "%s"
-    CF_API: "%s"
-    APP_ID: "%s"
-    SPACE_ID: "%s"
-    ORG_ID: "%s"
-    REGISTRY_USERNAME: "%s"
-    REGISTRY_PASSWORD: "%s"
-    PROMPT_BASE64: "%s"
-`, d.appName, token, prompterApiEndpoint, appID, spaceID, orgID, registryUsername, registryPassword, promptBase64)
+	fmt.Printf("Setting environment variables for prompter app '%s'...\n", d.appName)
 
-	if err := os.WriteFile(manifestPath, []byte(manifest), 0644); err != nil {
-		return fmt.Errorf("failed to write manifest: %w", err)
+	envVars := map[string]string{
+		"CF_ACCESS_TOKEN":   token,
+		"CF_API":            prompterApiEndpoint,
+		"APP_ID":            appID,
+		"SPACE_ID":          spaceID,
+		"ORG_ID":            orgID,
+		"REGISTRY_USERNAME": registryUsername,
+		"REGISTRY_PASSWORD": registryPassword,
+		"PROMPT_BASE64":     promptBase64,
 	}
 
-	fmt.Printf("Pushing prompter app '%s' to CF...\n", d.appName)
-
-	cmd := exec.Command("cf", "push", d.appName, "-p", tempDir, "-f", manifestPath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to push app: %w", err)
+	for key, value := range envVars {
+		if _, err := d.cliConnection.CliCommand("set-env", d.appName, key, value); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %w", key, err)
+		}
 	}
 
-	fmt.Println("Prompter app pushed successfully")
+	fmt.Printf("Starting prompter app '%s'...\n", d.appName)
+	if _, err := d.cliConnection.CliCommand("start", d.appName); err != nil {
+		return fmt.Errorf("failed to start app: %w", err)
+	}
+
+	fmt.Println("Prompter app started successfully")
 	return nil
 }
 
@@ -188,5 +153,128 @@ func (d *AppDeployer) Cleanup() error {
 	}
 
 	fmt.Println("Prompter app deleted successfully")
+	return nil
+}
+
+func (d *AppDeployer) StopPrompter() error {
+	fmt.Printf("Stopping prompter app '%s'...\n", d.appName)
+	if _, err := d.cliConnection.CliCommand("stop", d.appName); err != nil {
+		return fmt.Errorf("failed to stop app: %w", err)
+	}
+
+	fmt.Println("Prompter app stopped successfully")
+	return nil
+}
+
+type PrompterInitDeployer struct {
+	cliConnection plugin.CliConnection
+	appName       string
+	prompterName  string
+	cfClient      *cfclient.Client
+}
+
+func NewPrompterInitDeployer(cliConnection plugin.CliConnection, appName string) *PrompterInitDeployer {
+	return &PrompterInitDeployer{
+		cliConnection: cliConnection,
+		appName:       appName,
+		prompterName:  fmt.Sprintf("%s-prompter", appName),
+	}
+}
+
+func (d *PrompterInitDeployer) DeployPrompterApp(apiEndpoint, token string) error {
+	if strings.HasPrefix(strings.ToLower(token), "bearer ") {
+		token = token[7:]
+	}
+
+	client, err := cfclient.New(apiEndpoint, token)
+	if err != nil {
+		return fmt.Errorf("failed to create CF client: %w", err)
+	}
+	d.cfClient = client
+
+	currentSpace, err := d.cliConnection.GetCurrentSpace()
+	if err != nil {
+		return fmt.Errorf("failed to get current space: %w", err)
+	}
+
+	existingAppGUID, err := d.cfClient.GetAppGUID(d.prompterName, currentSpace.Guid)
+	if err == nil && existingAppGUID != "" {
+		fmt.Printf("Prompter app '%s' already exists, deleting...\n", d.prompterName)
+		if _, err := d.cliConnection.CliCommand("delete", d.prompterName, "-f"); err != nil {
+			return fmt.Errorf("failed to delete existing prompter app: %w", err)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	tempDir, err := os.MkdirTemp("", "cf-prompter-init-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	prompterBinaryPath := filepath.Join(tempDir, "prompter")
+
+	if len(PrompterBinary) == 0 {
+		return fmt.Errorf("prompter binary not embedded - ensure 'make build-prompter' was run before building the plugin")
+	}
+
+	if err := os.WriteFile(prompterBinaryPath, PrompterBinary, 0755); err != nil {
+		return fmt.Errorf("failed to write prompter binary: %w", err)
+	}
+
+	procfilePath := filepath.Join(tempDir, "Procfile")
+	procfile := "web: ./prompter\n"
+	if err := os.WriteFile(procfilePath, []byte(procfile), 0644); err != nil {
+		return fmt.Errorf("failed to write Procfile: %w", err)
+	}
+
+	manifestPath := filepath.Join(tempDir, "manifest.yml")
+	manifest := fmt.Sprintf(`---
+applications:
+- name: %s
+  memory: 1G
+  disk_quota: 2G
+  instances: 1
+  no-route: true
+  health-check-type: process
+  buildpack: paketo-buildpacks/procfile
+`, d.prompterName)
+
+	if err := os.WriteFile(manifestPath, []byte(manifest), 0644); err != nil {
+		return fmt.Errorf("failed to write manifest: %w", err)
+	}
+
+	fmt.Printf("Step 1/3: Preparing prompter app '%s'...\n", d.prompterName)
+
+	fmt.Printf("Step 2/3: Pushing prompter app")
+	progressDone := make(chan bool)
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				fmt.Print(".")
+			case <-progressDone:
+				return
+			}
+		}
+	}()
+
+	cmd := exec.Command("cf", "push", d.prompterName, "-p", tempDir, "-f", manifestPath)
+	output, err := cmd.CombinedOutput()
+	progressDone <- true
+	fmt.Println()
+
+	if err != nil {
+		fmt.Println(string(output))
+		return fmt.Errorf("failed to push app: %w", err)
+	}
+
+	fmt.Printf("Step 3/3: Stopping prompter app (ready for use)...\n")
+	if _, err := d.cliConnection.CliCommand("stop", d.prompterName); err != nil {
+		return fmt.Errorf("failed to stop prompter app: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Summary

This PR introduces a new `cf prompt-init` command that separates the one-time prompter app setup from the prompt execution workflow, making the system more efficient and user-friendly.

### Changes

1. **New `prompt-init` Command**
   - Adds `cf prompt-init <APP>` to push prompter app once during initial setup
   - Names prompter app as `<APP>-prompter` following the naming convention
   - Pushes app in stopped state, ready for use
   - Deletes existing prompter app if present before creating new one

2. **Improved Push Verbosity**
   - Shows high-level progress steps (1/3, 2/3, 3/3) instead of verbose cf push logs
   - Displays progress dots during long-running operations
   - Cleaner output focused on what matters to users

3. **Updated `prompt` Command**
   - Checks if `<APP>-prompter` exists before execution
   - Provides helpful error message with command to run if prompter doesn't exist
   - Sets environment variables dynamically when starting the prompter
   - Stops prompter app after execution instead of deleting it

4. **Refactored Deployer**
   - Split `AppDeployer` to support both init and execution workflows
   - New `PrompterInitDeployer` handles one-time setup
   - `AppDeployer` now starts existing prompter with environment variables
   - Added `StopPrompter` method for graceful shutdown

### Benefits

- **Performance**: Avoids re-pushing prompter app on every prompt execution
- **Clarity**: Separates setup from execution for better UX
- **Efficiency**: Environment variables set dynamically, not baked into manifest
- **Reusability**: Prompter app persists between prompt executions

### Usage

```bash
# One-time setup per application
cf prompt-init hello-world

# Execute prompts (can be run multiple times)
cf prompt hello-world -p "Add a new endpoint"
cf prompt hello-world -p "Fix the bug in authentication"
```

Fixes rkoster/rubionic-workspace#66